### PR TITLE
chore: comment ipmrovements

### DIFF
--- a/.cursor/rules/solidity-example-project.mdc
+++ b/.cursor/rules/solidity-example-project.mdc
@@ -1037,7 +1037,7 @@ contract AccessControlExtUpgradeableMock is AccessControlExtUpgradeable, UUPSUpg
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */
@@ -1090,7 +1090,7 @@ contract PausableExtUpgradeableMock is PausableExtUpgradeable, UUPSUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */
@@ -1143,7 +1143,7 @@ contract RescuableUpgradeableMock is RescuableUpgradeable, UUPSUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */
@@ -1199,7 +1199,7 @@ contract UUPSExtUpgradeableMock is UUPSExtUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */

--- a/.cursor/rules/solidity-example-project.mdc
+++ b/.cursor/rules/solidity-example-project.mdc
@@ -422,7 +422,7 @@ abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradeable contract
+     * @dev The unchained internal initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *
@@ -503,7 +503,7 @@ abstract contract PausableExtUpgradeable is AccessControlExtUpgradeable, Pausabl
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradeable contract
+     * @dev The unchained internal initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *
@@ -565,7 +565,7 @@ abstract contract RescuableUpgradeable is AccessControlExtUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradeable contract
+     * @dev The unchained internal initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *

--- a/.cursor/rules/solidity-example-project.mdc
+++ b/.cursor/rules/solidity-example-project.mdc
@@ -352,7 +352,7 @@ abstract contract BlueprintStorageLayout is IBlueprintTypes {
     /**
      * @dev Defines the contract storage structure.
      *
-     * The fields:
+     * Fields:
      *
      * - token ---------------- The address of the underlying token.
      * - operationalTreasury -- The address of the operational treasury.
@@ -938,7 +938,7 @@ interface IBlueprintTypes {
     /**
      * @dev The data of a single operation of the blueprint smart-contract.
      *
-     * The fields:
+     * Fields:
      *
      * - status --- The status of the operation according to the {OperationStatus} enum.
      * - account -- The address of the account involved in the operation.
@@ -954,7 +954,7 @@ interface IBlueprintTypes {
     /**
      * @dev The state of a single account within the blueprint smart-contract.
      *
-     * The fields:
+     * Fields:
      *
      * - lastOpId -------- The identifier of the last operation related to the account.
      * - balance --------- The balance of the account.
@@ -991,7 +991,7 @@ interface IVersionable {
     /**
      * @dev Defines the version of a contract.
      *
-     * The fields:
+     * Fields:
      *
      * - major -- The major version of the contract.
      * - minor -- The minor version of the contract.

--- a/.cursor/rules/solidity-example-project.mdc
+++ b/.cursor/rules/solidity-example-project.mdc
@@ -367,11 +367,11 @@ abstract contract BlueprintStorageLayout is IBlueprintTypes {
     struct BlueprintStorage {
         // Slot 1
         address token;
-        // uint96 __reserved1; // Reserved for future use until the end of the storage slot
+        // uint96 __reserved1; // Reserved until the end of the storage slot
 
         // Slot 2
         address operationalTreasury;
-        // uint96 __reserved2; // Reserved for future use until the end of the storage slot
+        // uint96 __reserved2; // Reserved until the end of the storage slot
 
         // Slot 3
         mapping(bytes32 opId => Operation operation) operations;
@@ -948,7 +948,7 @@ interface IBlueprintTypes {
         OperationStatus status;
         address account;
         uint64 amount;
-        // uint24 __reserved; // Reserved for future use until the end of the storage slot
+        // uint24 __reserved; // Reserved until the end of the storage slot
     }
 
     /**
@@ -968,7 +968,7 @@ interface IBlueprintTypes {
         // Slot 2
         uint64 balance;
         uint32 operationCount;
-        // uint160 __reserved; // Reserved for future use until the end of the storage slot
+        // uint160 __reserved; // Reserved until the end of the storage slot
     }
 }
 ```

--- a/.cursor/rules/solidity-rules.mdc
+++ b/.cursor/rules/solidity-rules.mdc
@@ -208,7 +208,7 @@ alwaysApply: false
      /**
       * @dev The data of a single operation of the blueprint smart-contract.
       *
-      * The fields:
+      * Fields:
       *
       * - status --- The status of the operation according to the {OperationStatus} enum.
       * - account -- The address of the account involved in the operation.

--- a/.cursor/rules/solidity-rules.mdc
+++ b/.cursor/rules/solidity-rules.mdc
@@ -218,7 +218,7 @@ alwaysApply: false
          uint8 status;
          address account;
          uint64 amount;
-         // uint24 __reserved; // Reserved for future use until the end of the storage slot
+         // uint24 __reserved; // Reserved until the end of the storage slot
      }
      ```
     
@@ -233,7 +233,7 @@ alwaysApply: false
         // Slot 2
         uint64 balance;
         uint32 operationCount;
-        // uint160 __reserved; // Reserved for future use until the end of the storage slot
+        // uint160 __reserved; // Reserved until the end of the storage slot
     }
     ```
 

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -222,7 +222,7 @@ contract CardPaymentProcessor is
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      *

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -380,7 +380,7 @@ contract CardPaymentProcessor is
         uint256 newExtraAmount
     ) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
         _updatePayment(
-            paymentId, // Tools: this comment prevents Prettier from formatting into a single line.
+            paymentId, // Tools: prevent Prettier one-liner
             newBaseAmount,
             newExtraAmount,
             UpdatingOperationKind.Full
@@ -477,7 +477,7 @@ contract CardPaymentProcessor is
         uint256 confirmationAmount
     ) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
         _updatePayment(
-            paymentId, // Tools: this comment prevents Prettier from formatting into a single line.
+            paymentId, // Tools: prevent Prettier one-liner
             newBaseAmount,
             newExtraAmount,
             UpdatingOperationKind.Lazy
@@ -496,7 +496,7 @@ contract CardPaymentProcessor is
      * - The result refund amount of the payment must not be higher than the new extra amount plus the base amount.
      */
     function refundPayment(
-        bytes32 paymentId, // Tools: this comment prevents Prettier from formatting into a single line.
+        bytes32 paymentId, // Tools: prevent Prettier one-liner
         uint256 refundingAmount
     ) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
         _refundPayment(paymentId, refundingAmount);
@@ -512,7 +512,7 @@ contract CardPaymentProcessor is
      * - The account address must not be zero.
      */
     function refundAccount(
-        address account, // Tools: this comment prevents Prettier from formatting into a single line.
+        address account, // Tools: prevent Prettier one-liner
         uint256 refundingAmount
     ) external whenNotPaused onlyRole(EXECUTOR_ROLE) {
         if (account == address(0)) {
@@ -520,7 +520,7 @@ contract CardPaymentProcessor is
         }
 
         emit AccountRefunded(
-            account, // Tools: this comment prevents Prettier from formatting into a single line.
+            account, // Tools: prevent Prettier one-liner
             refundingAmount,
             bytes("")
         );
@@ -693,13 +693,13 @@ contract CardPaymentProcessor is
         );
         if (eventFlags & EVENT_ADDENDUM_FLAG_MASK_SPONSORED != 0) {
             addendum = abi.encodePacked(
-                addendum, // Tools: this comment prevents Prettier from formatting into a single line.
+                addendum, // Tools: prevent Prettier one-liner
                 sponsor,
                 uint64(operation.sponsorSumAmount)
             );
         }
         emit PaymentMade(
-            operation.paymentId, // Tools: this comment prevents Prettier from formatting into a single line.
+            operation.paymentId, // Tools: prevent Prettier one-liner
             operation.payer,
             addendum
         );
@@ -762,7 +762,7 @@ contract CardPaymentProcessor is
             );
         }
         emit PaymentUpdated(
-            paymentId, // Tools: this comment prevents Prettier from formatting into a single line.
+            paymentId, // Tools: prevent Prettier one-liner
             payment.payer,
             addendum
         );
@@ -770,7 +770,7 @@ contract CardPaymentProcessor is
 
     /// @dev Cancels a payment internally.
     function _cancelPayment(
-        bytes32 paymentId, // Tools: this comment prevents Prettier from formatting into a single line.
+        bytes32 paymentId, // Tools: prevent Prettier one-liner
         PaymentStatus targetStatus
     ) internal {
         if (paymentId == 0) {
@@ -801,7 +801,7 @@ contract CardPaymentProcessor is
         );
         if (eventFlags & EVENT_ADDENDUM_FLAG_MASK_SPONSORED != 0) {
             addendum = abi.encodePacked(
-                addendum, // Tools: this comment prevents Prettier from formatting into a single line.
+                addendum, // Tools: prevent Prettier one-liner
                 sponsor,
                 uint64(oldPaymentDetails.sponsorRemainder)
             );
@@ -809,13 +809,13 @@ contract CardPaymentProcessor is
 
         if (targetStatus == PaymentStatus.Revoked) {
             emit PaymentRevoked(
-                paymentId, // Tools: this comment prevents Prettier from formatting into a single line.
+                paymentId, // Tools: prevent Prettier one-liner
                 payment.payer,
                 addendum
             );
         } else {
             emit PaymentReversed(
-                paymentId, // Tools: this comment prevents Prettier from formatting into a single line.
+                paymentId, // Tools: prevent Prettier one-liner
                 payment.payer,
                 addendum
             );
@@ -824,7 +824,7 @@ contract CardPaymentProcessor is
 
     /// @dev Confirms a payment internally.
     function _confirmPayment(
-        bytes32 paymentId, // Tools: this comment prevents Prettier from formatting into a single line.
+        bytes32 paymentId, // Tools: prevent Prettier one-liner
         uint256 confirmationAmount
     ) internal returns (uint256) {
         if (paymentId == 0) {
@@ -858,7 +858,7 @@ contract CardPaymentProcessor is
 
     /// @dev Confirms a payment internally with the token transfer to the cash-out account.
     function _confirmPaymentWithTransfer(
-        bytes32 paymentId, // Tools: this comment prevents Prettier from formatting into a single line.
+        bytes32 paymentId, // Tools: prevent Prettier one-liner
         uint256 confirmationAmount
     ) internal {
         confirmationAmount = _confirmPayment(paymentId, confirmationAmount);
@@ -870,7 +870,7 @@ contract CardPaymentProcessor is
 
     /// @dev Makes a refund for a payment internally.
     function _refundPayment(
-        bytes32 paymentId, // Tools: this comment prevents Prettier from formatting into a single line.
+        bytes32 paymentId, // Tools: prevent Prettier one-liner
         uint256 refundingAmount
     ) internal {
         if (paymentId == 0) {
@@ -913,7 +913,7 @@ contract CardPaymentProcessor is
         }
 
         emit PaymentRefunded(
-            paymentId, // Tools: this comment prevents Prettier from formatting into a single line.
+            paymentId, // Tools: prevent Prettier one-liner
             payment.payer,
             addendum
         );
@@ -1058,13 +1058,13 @@ contract CardPaymentProcessor is
         );
         if (eventFlags & EVENT_ADDENDUM_FLAG_MASK_SPONSORED != 0) {
             addendum = abi.encodePacked(
-                addendum, // Tools: this comment prevents Prettier from formatting into a single line.
+                addendum, // Tools: prevent Prettier one-liner
                 sponsor
             );
         }
 
         emit PaymentConfirmedAmountChanged(
-            paymentId, // Tools: this comment prevents Prettier from formatting into a single line.
+            paymentId, // Tools: prevent Prettier one-liner
             payer,
             addendum
         );
@@ -1082,7 +1082,7 @@ contract CardPaymentProcessor is
             CashbackOperationStatus status;
             (status, amount) = _increaseCashback(operation.payer, amount);
             emit CashbackSent(
-                operation.paymentId, // Tools: this comment prevents Prettier from formatting into a single line.
+                operation.paymentId, // Tools: prevent Prettier one-liner
                 operation.payer,
                 status,
                 amount
@@ -1186,7 +1186,7 @@ contract CardPaymentProcessor is
 
     /// @dev Stores the data of a newly created payment.
     function _storeNewPayment(
-        Payment storage storedPayment, // Tools: this comment prevents Prettier from formatting into a single line.
+        Payment storage storedPayment, // Tools: prevent Prettier one-liner
         MakingOperation memory operation
     ) internal {
         PaymentStatus oldStatus = storedPayment.status;

--- a/contracts/base/AccessControlExtUpgradeable.sol
+++ b/contracts/base/AccessControlExtUpgradeable.sol
@@ -22,7 +22,7 @@ abstract contract AccessControlExtUpgradeable is AccessControlUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradeable contract
+     * @dev The unchained internal initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *

--- a/contracts/base/BlocklistableUpgradeable.sol
+++ b/contracts/base/BlocklistableUpgradeable.sol
@@ -69,7 +69,7 @@ abstract contract BlocklistableUpgradeable is AccessControlExtUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradeable contract
+     * @dev The unchained internal initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *

--- a/contracts/base/PausableExtUpgradeable.sol
+++ b/contracts/base/PausableExtUpgradeable.sol
@@ -21,7 +21,7 @@ abstract contract PausableExtUpgradeable is AccessControlExtUpgradeable, Pausabl
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradeable contract
+     * @dev The unchained internal initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *

--- a/contracts/base/RescuableUpgradeable.sol
+++ b/contracts/base/RescuableUpgradeable.sol
@@ -25,7 +25,7 @@ abstract contract RescuableUpgradeable is AccessControlExtUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The unchained internal initializer of the upgradeable contract
+     * @dev The unchained internal initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/contracts/5.x/upgradeable#multiple-inheritance
      *

--- a/contracts/interfaces/ICardPaymentCashback.sol
+++ b/contracts/interfaces/ICardPaymentCashback.sol
@@ -41,7 +41,7 @@ interface ICardPaymentCashbackTypes {
         uint72 totalAmount;
         uint72 capPeriodStartAmount;
         uint32 capPeriodStartTime;
-        // uint80 __reserved; // Reserved for future use until the end of the storage slot
+        // uint80 __reserved; // Reserved until the end of the storage slot
     }
 }
 

--- a/contracts/interfaces/ICardPaymentCashback.sol
+++ b/contracts/interfaces/ICardPaymentCashback.sol
@@ -30,7 +30,7 @@ interface ICardPaymentCashbackTypes {
     /**
      * @dev The cashback-related data of a single account.
      *
-     * The fields:
+     * Fields:
      *
      * - totalAmount ----------- The total amount of cashback that has been sent to the account.
      * - capPeriodStartAmount -- The amount of cashback that has been sent to the account during the current cap period.

--- a/contracts/interfaces/ICardPaymentProcessor.sol
+++ b/contracts/interfaces/ICardPaymentProcessor.sol
@@ -138,7 +138,7 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
 
     /// @dev Emitted when the cash-out account is changed.
     event CashOutAccountChanged(
-        address oldCashOutAccount, // Tools: this comment prevents Prettier from formatting into a single line.
+        address oldCashOutAccount, // Tools: prevent Prettier one-liner
         address newCashOutAccount
     );
 

--- a/contracts/interfaces/ICardPaymentProcessor.sol
+++ b/contracts/interfaces/ICardPaymentProcessor.sol
@@ -33,7 +33,7 @@ interface ICardPaymentProcessorTypes {
 
     /** @dev The data of a single payment for retention in the contract storage.
      *
-     * The fields:
+     * Fields:
      *
      * - status ----------- The current status of the payment.
      * - reserve1 --------- The reserved field for future changes.
@@ -97,7 +97,7 @@ interface ICardPaymentProcessorTypes {
     /**
      * @dev The data of a single confirmation operation to use in the appropriate function as an input parameter.
      *
-     * The fields:
+     * Fields:
      *
      * - paymentId -- The card transaction payment ID from the off-chain card processing backend.
      * - amount ----- The amount to confirm for the payment.
@@ -110,7 +110,7 @@ interface ICardPaymentProcessorTypes {
     /**
      * @dev The statistics of all payments for retention in the contract storage.
      *
-     * The fields:
+     * Fields:
      *
      * - totalUnconfirmedRemainder -- The total remainder of all payments that are not confirmed yet.
      * - reserve1 ------------------- The reserved field for future changes.

--- a/contracts/interfaces/IVersionable.sol
+++ b/contracts/interfaces/IVersionable.sol
@@ -13,7 +13,7 @@ interface IVersionable {
     /**
      * @dev Defines the version of a contract.
      *
-     * The fields:
+     * Fields:
      *
      * - major -- The major version of the contract.
      * - minor -- The minor version of the contract.

--- a/contracts/mocks/base/AccessControlExtUpgradeableMock.sol
+++ b/contracts/mocks/base/AccessControlExtUpgradeableMock.sol
@@ -18,7 +18,7 @@ contract AccessControlExtUpgradeableMock is AccessControlExtUpgradeable, UUPSUpg
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */

--- a/contracts/mocks/base/BlocklistableUpgradeableMock.sol
+++ b/contracts/mocks/base/BlocklistableUpgradeableMock.sol
@@ -20,7 +20,7 @@ contract BlocklistableUpgradeableMock is BlocklistableUpgradeable, UUPSUpgradeab
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */

--- a/contracts/mocks/base/PausableExtUpgradeableMock.sol
+++ b/contracts/mocks/base/PausableExtUpgradeableMock.sol
@@ -15,7 +15,7 @@ contract PausableExtUpgradeableMock is PausableExtUpgradeable, UUPSUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */

--- a/contracts/mocks/base/RescuableUpgradeableMock.sol
+++ b/contracts/mocks/base/RescuableUpgradeableMock.sol
@@ -15,7 +15,7 @@ contract RescuableUpgradeableMock is RescuableUpgradeable, UUPSUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */

--- a/contracts/mocks/base/UUPSExtUpgradeableMock.sol
+++ b/contracts/mocks/base/UUPSExtUpgradeableMock.sol
@@ -18,7 +18,7 @@ contract UUPSExtUpgradeableMock is UUPSExtUpgradeable {
     // ------------------ Initializers ---------------------------- //
 
     /**
-     * @dev The initialize function of the upgradeable contract.
+     * @dev Initializer of the upgradeable contract.
      *
      * See details: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable
      */


### PR DESCRIPTION
# Main Changes

1. Fixed punctuation in NatSpec comments.
1. Standardized the comments for initializers, constructors. storage slots within structures.
1. Shortened the tool comments that prevents Prettier from formatting into a single line.

Issue:
https://github.com/cloudwalk/product-smart-contracts/issues/199
