### PR TITLE
Contract interface separation

### DIFF
--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -15,6 +15,8 @@ import { Versionable } from "./base/Versionable.sol";
 import { CardPaymentProcessorStorage } from "./CardPaymentProcessorStorage.sol";
 import { ICardPaymentProcessor } from "./interfaces/ICardPaymentProcessor.sol";
 import { ICardPaymentCashback } from "./interfaces/ICardPaymentCashback.sol";
+import { ICardPaymentCashbackPrimary } from "./interfaces/ICardPaymentCashback.sol";
+import { ICardPaymentCashbackConfiguration } from "./interfaces/ICardPaymentCashback.sol";
 
 /**
  * @title CardPaymentProcessor contract
@@ -529,7 +531,7 @@ contract CardPaymentProcessor is
     }
 
     /**
-     * @inheritdoc ICardPaymentCashback
+     * @inheritdoc ICardPaymentCashbackConfiguration
      *
      * @dev Requirements:
      *
@@ -554,7 +556,7 @@ contract CardPaymentProcessor is
     }
 
     /**
-     * @inheritdoc ICardPaymentCashback
+     * @inheritdoc ICardPaymentCashbackConfiguration
      *
      * @dev Requirements:
      *
@@ -577,7 +579,7 @@ contract CardPaymentProcessor is
     }
 
     /**
-     * @inheritdoc ICardPaymentCashback
+     * @inheritdoc ICardPaymentCashbackConfiguration
      *
      * @dev Requirements:
      *
@@ -599,7 +601,7 @@ contract CardPaymentProcessor is
     }
 
     /**
-     * @inheritdoc ICardPaymentCashback
+     * @inheritdoc ICardPaymentCashbackConfiguration
      *
      * @dev Requirements:
      *
@@ -638,22 +640,22 @@ contract CardPaymentProcessor is
         return _paymentStatistics;
     }
 
-    /// @inheritdoc ICardPaymentCashback
+    /// @inheritdoc ICardPaymentCashbackPrimary
     function cashbackTreasury() external view returns (address) {
         return _cashbackTreasury;
     }
 
-    /// @inheritdoc ICardPaymentCashback
+    /// @inheritdoc ICardPaymentCashbackPrimary
     function cashbackEnabled() external view returns (bool) {
         return _cashbackEnabled;
     }
 
-    /// @inheritdoc ICardPaymentCashback
+    /// @inheritdoc ICardPaymentCashbackPrimary
     function cashbackRate() external view returns (uint256) {
         return _cashbackRate;
     }
 
-    /// @inheritdoc ICardPaymentCashback
+    /// @inheritdoc ICardPaymentCashbackPrimary
     function getAccountCashbackState(address account) external view returns (AccountCashbackState memory) {
         return _accountCashbackStates[account];
     }

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -14,6 +14,8 @@ import { Versionable } from "./base/Versionable.sol";
 
 import { CardPaymentProcessorStorage } from "./CardPaymentProcessorStorage.sol";
 import { ICardPaymentProcessor } from "./interfaces/ICardPaymentProcessor.sol";
+import { ICardPaymentProcessorPrimary } from "./interfaces/ICardPaymentProcessor.sol";
+import { ICardPaymentProcessorConfiguration } from "./interfaces/ICardPaymentProcessor.sol";
 import { ICardPaymentCashback } from "./interfaces/ICardPaymentCashback.sol";
 import { ICardPaymentCashbackPrimary } from "./interfaces/ICardPaymentCashback.sol";
 import { ICardPaymentCashbackConfiguration } from "./interfaces/ICardPaymentCashback.sol";
@@ -126,65 +128,6 @@ contract CardPaymentProcessor is
     /// @dev Default version of the event addendum.
     uint8 internal constant EVENT_ADDENDUM_DEFAULT_VERSION = 1;
 
-    // ------------------ Errors ---------------------------------- //
-
-    /// @dev The zero payer address has been passed as a function argument.
-    error AccountZeroAddress();
-
-    /// @dev The cash-out account is not configured.
-    error CashOutAccountNotConfigured();
-
-    /// @dev A new cash-out account is the same as the previously set one.
-    error CashOutAccountUnchanged();
-
-    /// @dev Thrown if the provided new implementation address is not of a card payment processor contract.
-    error ImplementationAddressInvalid();
-
-    /// @dev The requested confirmation amount does not meet the requirements.
-    error InappropriateConfirmationAmount();
-
-    /**
-     * @dev The payment with the provided ID has an inappropriate status.
-     * @param paymentId The ID of the payment that does not exist.
-     * @param currentStatus The current status of the payment.
-     */
-    error InappropriatePaymentStatus(bytes32 paymentId, PaymentStatus currentStatus);
-
-    /// @dev The requested refunding amount does not meet the requirements.
-    error InappropriateRefundingAmount();
-
-    /// @dev The requested or result or updated sum amount (base + extra) does not meet the requirements.
-    error InappropriateSumAmount();
-
-    /// @dev The requested subsidy limit is greater than the allowed maximum to store.
-    error OverflowOfSubsidyLimit();
-
-    /// @dev The requested or result or updated sum amount (base + extra) is greater than the allowed maximum to store.
-    error OverflowOfSumAmount();
-
-    /// @dev The zero payer address has been passed as a function argument.
-    error PayerZeroAddress();
-
-    /// @dev The payment with the provided ID already exists and is not revoked.
-    error PaymentAlreadyExistent();
-
-    /// @dev The array of payment confirmations is empty.
-    error PaymentConfirmationArrayEmpty();
-
-    /**
-     * @dev The payment with the provided ID does not exist.
-     * @param paymentId The ID of the payment that does not exist.
-     */
-    error PaymentNonExistent(bytes32 paymentId);
-
-    /// @dev Zero payment ID has been passed as a function argument.
-    error PaymentZeroId();
-
-    /// @dev The sponsor address is zero while the subsidy limit is non-zero.
-    error SponsorZeroAddress();
-
-    /// @dev The zero token address has been passed as a function argument.
-    error TokenZeroAddress();
 
     // ------------------ Constructor ----------------------------- //
 
@@ -233,7 +176,7 @@ contract CardPaymentProcessor is
     // ------------------ Transactional functions ----------------- //
 
     /**
-     * @inheritdoc ICardPaymentProcessor
+     * @inheritdoc ICardPaymentProcessorConfiguration
      *
      * @dev Requirements:
      *
@@ -253,7 +196,7 @@ contract CardPaymentProcessor is
     }
 
     /**
-     * @inheritdoc ICardPaymentProcessor
+     * @inheritdoc ICardPaymentProcessorPrimary
      *
      * @dev Requirements:
      *
@@ -309,7 +252,7 @@ contract CardPaymentProcessor is
     }
 
     /**
-     * @inheritdoc ICardPaymentProcessor
+     * @inheritdoc ICardPaymentProcessorPrimary
      *
      * @dev Requirements:
      *
@@ -346,7 +289,7 @@ contract CardPaymentProcessor is
     }
 
     /**
-     * @inheritdoc ICardPaymentProcessor
+     * @inheritdoc ICardPaymentProcessorPrimary
      *
      * @dev Requirements:
      *
@@ -369,7 +312,7 @@ contract CardPaymentProcessor is
     }
 
     /**
-     * @inheritdoc ICardPaymentProcessor
+     * @inheritdoc ICardPaymentProcessorPrimary
      *
      * @dev Requirements:
      *
@@ -382,7 +325,7 @@ contract CardPaymentProcessor is
     }
 
     /**
-     * @inheritdoc ICardPaymentProcessor
+     * @inheritdoc ICardPaymentProcessorPrimary
      *
      * @dev Requirements:
      *
@@ -395,7 +338,7 @@ contract CardPaymentProcessor is
     }
 
     /**
-     * @inheritdoc ICardPaymentProcessor
+     * @inheritdoc ICardPaymentProcessorPrimary
      *
      * @dev Requirements:
      *
@@ -411,7 +354,7 @@ contract CardPaymentProcessor is
     }
 
     /**
-     * @inheritdoc ICardPaymentProcessor
+     * @inheritdoc ICardPaymentProcessorPrimary
      *
      * @dev Requirements:
      *
@@ -442,7 +385,7 @@ contract CardPaymentProcessor is
     }
 
     /**
-     * @inheritdoc ICardPaymentProcessor
+     * @inheritdoc ICardPaymentProcessorPrimary
      *
      * @dev Requirements:
      *
@@ -467,7 +410,7 @@ contract CardPaymentProcessor is
     }
 
     /**
-     * @inheritdoc ICardPaymentProcessor
+     * @inheritdoc ICardPaymentProcessorPrimary
      *
      * @dev Requirements:
      *
@@ -484,7 +427,7 @@ contract CardPaymentProcessor is
     }
 
     /**
-     * @inheritdoc ICardPaymentProcessor
+     * @inheritdoc ICardPaymentProcessorPrimary
      *
      * @dev Requirements:
      *
@@ -599,22 +542,22 @@ contract CardPaymentProcessor is
 
     // ------------------ View functions -------------------------- //
 
-    /// @inheritdoc ICardPaymentProcessor
+    /// @inheritdoc ICardPaymentProcessorPrimary
     function cashOutAccount() external view returns (address) {
         return _cashOutAccount;
     }
 
-    /// @inheritdoc ICardPaymentProcessor
+    /// @inheritdoc ICardPaymentProcessorPrimary
     function token() external view returns (address) {
         return _token;
     }
 
-    /// @inheritdoc ICardPaymentProcessor
+    /// @inheritdoc ICardPaymentProcessorPrimary
     function getPayment(bytes32 paymentId) external view returns (Payment memory) {
         return _payments[paymentId];
     }
 
-    /// @inheritdoc ICardPaymentProcessor
+    /// @inheritdoc ICardPaymentProcessorPrimary
     function getPaymentStatistics() external view returns (PaymentStatistics memory) {
         return _paymentStatistics;
     }
@@ -641,7 +584,7 @@ contract CardPaymentProcessor is
 
     // ------------------ Pure functions -------------------------- //
 
-    /// @inheritdoc ICardPaymentProcessor
+    /// @inheritdoc ICardPaymentProcessorPrimary
     function proveCardPaymentProcessor() external pure {}
 
     // ------------------ Internal functions ---------------------- //

--- a/contracts/CardPaymentProcessor.sol
+++ b/contracts/CardPaymentProcessor.sol
@@ -131,27 +131,6 @@ contract CardPaymentProcessor is
     /// @dev The zero payer address has been passed as a function argument.
     error AccountZeroAddress();
 
-    /// @dev The cashback operations are already enabled.
-    error CashbackAlreadyEnabled();
-
-    /// @dev The cashback operations are already disabled.
-    error CashbackAlreadyDisabled();
-
-    /// @dev The cashback treasury address is the same as previously set one.
-    error CashbackTreasuryUnchanged();
-
-    /// @dev The cashback treasury address is not configured.
-    error CashbackTreasuryNotConfigured();
-
-    /// @dev The zero cashback treasury address has been passed as a function argument.
-    error CashbackTreasuryZeroAddress();
-
-    /// @dev The provided cashback rate exceeds the allowed maximum.
-    error CashbackRateExcess();
-
-    /// @dev A new cashback rate is the same as previously set one.
-    error CashbackRateUnchanged();
-
     /// @dev The cash-out account is not configured.
     error CashOutAccountNotConfigured();
 

--- a/contracts/base/Versionable.sol
+++ b/contracts/base/Versionable.sol
@@ -12,6 +12,6 @@ import "../interfaces/IVersionable.sol";
 abstract contract Versionable is IVersionable {
     /// @inheritdoc IVersionable
     function $__VERSION() external pure returns (Version memory) {
-        return Version(2, 2, 0);
+        return Version(2, 2, 1);
     }
 }

--- a/contracts/interfaces/ICardPaymentCashback.sol
+++ b/contracts/interfaces/ICardPaymentCashback.sol
@@ -46,11 +46,11 @@ interface ICardPaymentCashbackTypes {
 }
 
 /**
- * @title ICardPaymentCashback interface
+ * @title ICardPaymentCashbackPrimary interface
  * @author CloudWalk Inc. (See https://www.cloudwalk.io)
- * @dev Defines the interface of the wrapper contract for the card payment cashback operations.
+ * @dev Defines the primary interface of the wrapper contract for the card payment cashback operations.
  */
-interface ICardPaymentCashback is ICardPaymentCashbackTypes {
+interface ICardPaymentCashbackPrimary is ICardPaymentCashbackTypes {
     // ------------------ Events ---------------------------------- //
 
     /**
@@ -120,6 +120,30 @@ interface ICardPaymentCashback is ICardPaymentCashbackTypes {
     /// @dev Emitted when cashback operations for new payments are disabled. Does not affect the existing payments.
     event CashbackDisabled();
 
+    // ------------------ View functions -------------------------- //
+
+    /// @dev Returns the current cashback treasury address.
+    function cashbackTreasury() external view returns (address);
+
+    /// @dev Checks if the cashback operations are enabled.
+    function cashbackEnabled() external view returns (bool);
+
+    /// @dev Returns the current cashback rate.
+    function cashbackRate() external view returns (uint256);
+
+    /**
+     * @dev Returns a structure with cashback-related data for a single account.
+     * @param account The account address to get the cashback state for.
+     */
+    function getAccountCashbackState(address account) external view returns (AccountCashbackState memory);
+}
+
+/**
+ * @title ICardPaymentCashbackConfiguration interface
+ * @author CloudWalk Inc. (See https://www.cloudwalk.io)
+ * @dev The configuration interface of the wrapper contract for the card payment cashback operations.
+ */
+interface ICardPaymentCashbackConfiguration {
     // ------------------ Transactional functions ----------------- //
 
     /**
@@ -153,21 +177,26 @@ interface ICardPaymentCashback is ICardPaymentCashbackTypes {
      * Emits a {CashbackDisabled} event.
      */
     function disableCashback() external;
+}
 
-    // ------------------ View functions -------------------------- //
+/**
+ * @title ICardPaymentCashbackErrors interface
+ * @author CloudWalk Inc. (See https://www.cloudwalk.io)
+ * @dev The custom errors used in the wrapper contract for the card payment cashback operations.
+ */
+interface ICardPaymentCashbackErrors {
 
-    /// @dev Returns the current cashback treasury address.
-    function cashbackTreasury() external view returns (address);
+}
 
-    /// @dev Checks if the cashback operations are enabled.
-    function cashbackEnabled() external view returns (bool);
+/**
+ * @title ICardPaymentCashback interface
+ * @author CloudWalk Inc. (See https://www.cloudwalk.io)
+ * @dev The full interface of the wrapper contract for the card payment cashback operations.
+ */
+interface ICardPaymentCashback is
+    ICardPaymentCashbackPrimary,
+    ICardPaymentCashbackConfiguration,
+    ICardPaymentCashbackErrors
+{
 
-    /// @dev Returns the current cashback rate.
-    function cashbackRate() external view returns (uint256);
-
-    /**
-     * @dev Returns a structure with cashback-related data for a single account.
-     * @param account The account address to get the cashback state for.
-     */
-    function getAccountCashbackState(address account) external view returns (AccountCashbackState memory);
 }

--- a/contracts/interfaces/ICardPaymentCashback.sol
+++ b/contracts/interfaces/ICardPaymentCashback.sol
@@ -52,21 +52,6 @@ interface ICardPaymentCashbackTypes {
  */
 interface ICardPaymentCashbackPrimary is ICardPaymentCashbackTypes {
     // ------------------ Events ---------------------------------- //
-
-    /**
-     * @dev Emitted when the cashback rate is changed.
-     * @param oldRate The value of the old cashback rate.
-     * @param newRate The value of the new cashback rate.
-     */
-    event CashbackRateChanged(uint256 oldRate, uint256 newRate);
-
-    /**
-     * @dev Emitted when the cashback treasury address is changed.
-     * @param oldTreasury The address of the old cashback treasury.
-     * @param newTreasury The address of the new cashback treasury.
-     */
-    event CashbackTreasuryChanged(address oldTreasury, address newTreasury);
-
     /**
      * @dev Emitted when a cashback sending request is executed, successfully or not.
      * @param paymentId The associated card transaction payment ID from the off-chain card processing backend.
@@ -114,12 +99,6 @@ interface ICardPaymentCashbackPrimary is ICardPaymentCashbackTypes {
         uint256 newCashbackAmount
     );
 
-    /// @dev Emitted when cashback operations for new payments are enabled. Does not affect the existing payments.
-    event CashbackEnabled();
-
-    /// @dev Emitted when cashback operations for new payments are disabled. Does not affect the existing payments.
-    event CashbackDisabled();
-
     // ------------------ View functions -------------------------- //
 
     /// @dev Returns the current cashback treasury address.
@@ -144,6 +123,28 @@ interface ICardPaymentCashbackPrimary is ICardPaymentCashbackTypes {
  * @dev The configuration interface of the wrapper contract for the card payment cashback operations.
  */
 interface ICardPaymentCashbackConfiguration {
+    // ------------------ Events ---------------------------------- //
+
+    /**
+     * @dev Emitted when the cashback rate is changed.
+     * @param oldRate The value of the old cashback rate.
+     * @param newRate The value of the new cashback rate.
+     */
+    event CashbackRateChanged(uint256 oldRate, uint256 newRate);
+
+    /**
+     * @dev Emitted when the cashback treasury address is changed.
+     * @param oldTreasury The address of the old cashback treasury.
+     * @param newTreasury The address of the new cashback treasury.
+     */
+    event CashbackTreasuryChanged(address oldTreasury, address newTreasury);
+
+    /// @dev Emitted when cashback operations for new payments are enabled. Does not affect the existing payments.
+    event CashbackEnabled();
+
+    /// @dev Emitted when cashback operations for new payments are disabled. Does not affect the existing payments.
+    event CashbackDisabled();
+
     // ------------------ Transactional functions ----------------- //
 
     /**
@@ -185,7 +186,26 @@ interface ICardPaymentCashbackConfiguration {
  * @dev The custom errors used in the wrapper contract for the card payment cashback operations.
  */
 interface ICardPaymentCashbackErrors {
+    /// @dev The cashback operations are already enabled.
+    error CashbackAlreadyEnabled();
 
+    /// @dev The cashback operations are already disabled.
+    error CashbackAlreadyDisabled();
+
+    /// @dev The cashback treasury address is the same as previously set one.
+    error CashbackTreasuryUnchanged();
+
+    /// @dev The cashback treasury address is not configured.
+    error CashbackTreasuryNotConfigured();
+
+    /// @dev The zero cashback treasury address has been passed as a function argument.
+    error CashbackTreasuryZeroAddress();
+
+    /// @dev The provided cashback rate exceeds the allowed maximum.
+    error CashbackRateExcess();
+
+    /// @dev A new cashback rate is the same as previously set one.
+    error CashbackRateUnchanged();
 }
 
 /**

--- a/contracts/interfaces/ICardPaymentProcessor.sol
+++ b/contracts/interfaces/ICardPaymentProcessor.sol
@@ -129,18 +129,12 @@ interface ICardPaymentProcessorTypes {
 }
 
 /**
- * @title ICardPaymentProcessor interface
+ * @title ICardPaymentProcessorPrimary interface
  * @author CloudWalk Inc. (See https://www.cloudwalk.io)
- * @dev Defines the interface of the wrapper contract for the card payment operations.
+ * @dev Defines the primary interface of the wrapper contract for the card payment operations.
  */
-interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
+interface ICardPaymentProcessorPrimary is ICardPaymentProcessorTypes {
     // ------------------ Events ---------------------------------- //
-
-    /// @dev Emitted when the cash-out account is changed.
-    event CashOutAccountChanged(
-        address oldCashOutAccount, // Tools: prevent Prettier one-liner
-        address newCashOutAccount
-    );
 
     /**
      * @dev Emitted when a payment is made.
@@ -279,17 +273,6 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
     event AccountRefunded(address indexed account, uint256 refundingAmount, bytes addendum);
 
     // ------------------ Transactional functions ----------------- //
-
-    /**
-     * @dev Sets the cash-out account address that will receive tokens of confirmed payments.
-     *
-     * This function can be called by a limited number of accounts that are allowed to configure the contract.
-     *
-     * Emits a {CashOutAccountChanged} event.
-     *
-     * @param newCashOutAccount The new cash-out account address.
-     */
-    function setCashOutAccount(address newCashOutAccount) external;
 
     /**
      * @dev Makes a card payment for a given account initiated by a service account.
@@ -476,4 +459,108 @@ interface ICardPaymentProcessor is ICardPaymentProcessorTypes {
 
     /// @dev Proves the contract is the card payment processor one. A marker function.
     function proveCardPaymentProcessor() external pure;
+}
+
+/**
+ * @title ICardPaymentProcessorConfiguration interface
+ * @author CloudWalk Inc. (See https://www.cloudwalk.io)
+ * @dev The configuration interface of the wrapper contract for the card payment operations.
+ */
+interface ICardPaymentProcessorConfiguration {
+    // ------------------ Events ---------------------------------- //
+
+    /// @dev Emitted when the cash-out account is changed.
+    event CashOutAccountChanged(
+        address oldCashOutAccount, // Tools: prevent Prettier one-liner
+        address newCashOutAccount
+    );
+
+    /**
+     * @dev Sets the cash-out account address that will receive tokens of confirmed payments.
+     *
+     * This function can be called by a limited number of accounts that are allowed to configure the contract.
+     *
+     * Emits a {CashOutAccountChanged} event.
+     *
+     * @param newCashOutAccount The new cash-out account address.
+     */
+    function setCashOutAccount(address newCashOutAccount) external;
+}
+
+/**
+ * @title ICardPaymentProcessorErrors interface
+ * @author CloudWalk Inc. (See https://www.cloudwalk.io)
+ * @dev The custom errors used in the wrapper contract for the card payment operations.
+ */
+interface ICardPaymentProcessorErrors is ICardPaymentProcessorTypes {
+    /// @dev The zero payer address has been passed as a function argument.
+    error AccountZeroAddress();
+
+    /// @dev The cash-out account is not configured.
+    error CashOutAccountNotConfigured();
+
+    /// @dev A new cash-out account is the same as the previously set one.
+    error CashOutAccountUnchanged();
+
+    /// @dev Thrown if the provided new implementation address is not of a card payment processor contract.
+    error ImplementationAddressInvalid();
+
+    /// @dev The requested confirmation amount does not meet the requirements.
+    error InappropriateConfirmationAmount();
+
+    /**
+     * @dev The payment with the provided ID has an inappropriate status.
+     * @param paymentId The ID of the payment that does not exist.
+     * @param currentStatus The current status of the payment.
+     */
+    error InappropriatePaymentStatus(bytes32 paymentId, PaymentStatus currentStatus);
+
+    /// @dev The requested refunding amount does not meet the requirements.
+    error InappropriateRefundingAmount();
+
+    /// @dev The requested or result or updated sum amount (base + extra) does not meet the requirements.
+    error InappropriateSumAmount();
+
+    /// @dev The requested subsidy limit is greater than the allowed maximum to store.
+    error OverflowOfSubsidyLimit();
+
+    /// @dev The requested or result or updated sum amount (base + extra) is greater than the allowed maximum to store.
+    error OverflowOfSumAmount();
+
+    /// @dev The zero payer address has been passed as a function argument.
+    error PayerZeroAddress();
+
+    /// @dev The payment with the provided ID already exists and is not revoked.
+    error PaymentAlreadyExistent();
+
+    /// @dev The array of payment confirmations is empty.
+    error PaymentConfirmationArrayEmpty();
+
+    /**
+     * @dev The payment with the provided ID does not exist.
+     * @param paymentId The ID of the payment that does not exist.
+     */
+    error PaymentNonExistent(bytes32 paymentId);
+
+    /// @dev Zero payment ID has been passed as a function argument.
+    error PaymentZeroId();
+
+    /// @dev The sponsor address is zero while the subsidy limit is non-zero.
+    error SponsorZeroAddress();
+
+    /// @dev The zero token address has been passed as a function argument.
+    error TokenZeroAddress();
+}
+
+/**
+ * @title ICardPaymentProcessor interface
+ * @author CloudWalk Inc. (See https://www.cloudwalk.io)
+ * @dev The full interface of the wrapper contract for the card payment operations.
+ */
+interface ICardPaymentProcessor is
+    ICardPaymentProcessorPrimary,
+    ICardPaymentProcessorConfiguration,
+    ICardPaymentProcessorErrors
+{
+
 }

--- a/test/CardPaymentProcessor.test.ts
+++ b/test/CardPaymentProcessor.test.ts
@@ -1498,7 +1498,7 @@ describe("Contract 'CardPaymentProcessor'", async () => {
   const EXPECTED_VERSION: Version = {
     major: 2,
     minor: 2,
-    patch: 0
+    patch: 1
   };
 
   // Errors of the library contracts


### PR DESCRIPTION
## Main changes

1. Moved all events, errors, and types from CardPaymentCashback and CardPaymentProcessor to their respective interfaces.

1. Split base contract interfaces into Errors, Configuration, and Primary interfaces.

## Versioning

The smart contracts version has been updated to `v.2.2.1`.

Resolves https://github.com/cloudwalk/product-smart-contracts/issues/205